### PR TITLE
Add cop for BlockLength

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1064,6 +1064,11 @@ Metrics/AbcSize:
   # a Float.
   Max: 15
 
+Metrics/BlockLength:
+  CountComments: false
+  Max: 25
+  ExcludedMethods: ["describe", "context", "it"]
+
 Metrics/BlockNesting:
   Max: 3
 


### PR DESCRIPTION
This cop discriminates against blocks that are too long (by default 25
lines). It also does not like blocks inside specs, which leads to lots
of complaints in RSpec tests.
The cop takes an argument to ignore certain methods, so I provided an
array with the common RSpec methods `["describe", "context", "it"]`.