### PR TITLE
Allow long lines in Rspec with the regex `expect`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1088,6 +1088,7 @@ Metrics/LineLength:
   URISchemes:
     - http
     - https
+  IgnoredPatterns: ["expect"]
 
 Metrics/MethodLength:
   CountComments: false  # count full line comments?


### PR DESCRIPTION
RSpec test often are quite verbose. To have the LineLength cop not
complain about long lines, we integrate an "IgnoredPattern" with
"expect". Whenever a line has the keyword expect in it, the LineLength
cop will not be triggered.