### PR TITLE
Add rubocop rspec

### DIFF
--- a/linter.gemspec
+++ b/linter.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   spec.add_dependency "rubocop", "~> 0.63.1"
+  spec.add_dependency "rubocop-rspec"
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -6,6 +6,9 @@
 #   - disabled.yml
 
 # Common configuration.
+
+require: rubocop-rspec
+
 AllCops:
   # Include common Ruby source files.
   Include:


### PR DESCRIPTION
With this commit it is possible after installing the rubocop.yml via the rake task as described in the documentation, to use rspec cops in the specific project where this linter branch is used. Tested with Metropolis project.
Cops default setting can be viewed here:
https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecdescribemethod

Cops can be configured directly by adding them to rubocop.yml via
Rspec/<copname>
    option1: value,
    option2: value,
    etc.


