### PR TITLE
Revert rubocop version to 0.63.0 to be compatible with CodeClimate

### DIFF
--- a/linter.gemspec
+++ b/linter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.add_dependency "rubocop", "~> 0.63.1"
+  spec.add_dependency "rubocop", "~> 0.63.0"
   spec.add_dependency "rubocop-rspec"
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Rubocop Version 0.63.1 is not compatible with codeclimate-rubocop
This commit will set the used rubocop version back to 0.63